### PR TITLE
revert to apt installs of scipy, yaml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,8 +89,16 @@ RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         python-dev \
         python-pip \
+        python-scipy \
+        python-yaml && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         python3-dev \
-        python3-pip && \
+        python3-pip \
+        python3-scipy \
+        python3-yaml && \
     rm -rf /var/lib/apt/lists/*
 
 # Mellanox OFED version 4.5-1.0.1.0

--- a/base.py
+++ b/base.py
@@ -1,4 +1,4 @@
-"""JEDI docker_base container
+"""Prototype JEDI docker_base container
 
 Usage:
 $ ../hpc-container-maker/hpccm.py --recipe base.py --format docker > Dockerfile
@@ -39,7 +39,12 @@ Stage0 += shell(commands=
 Stage0 += apt_get(ospackages=['autoconf','pkg-config','ddd','gdb','kdbg','valgrind'])
     
 # python
-Stage0 += apt_get(ospackages=['python-pip','python-dev','python3-pip','python3-dev'])
+Stage0 += apt_get(ospackages=['python-pip','python-dev','python-yaml',
+                              'python-scipy'])
+
+# python
+Stage0 += apt_get(ospackages=['python3-pip','python3-dev','python3-yaml',
+                              'python3-scipy'])
 
 # Mellanox OFED
 Stage0 += mlnx_ofed(version='4.5-1.0.1.0')


### PR DESCRIPTION
Apologies for another PR here but it turns out that the scipy and yaml python modules need to be installed with apt rather than ```python -m pip```.  I could have sworn that the latter worked the first time I tried it but be that as it may, those pip installs were breaking the container build.  So, I reverted.  These two are the only exceptions - the other python modules are installed with jedi-stack.