### PR TITLE
Feature/new dev containers

### DIFF
--- a/Dockerfile.clang-mpich-dev-hpc
+++ b/Dockerfile.clang-mpich-dev-hpc
@@ -20,11 +20,8 @@ RUN apt-get update -y && \
         flex \
         ksh \
         less \
-        libboost-thread-dev \
         libcurl4-openssl-dev \
         libexpat1-dev \
-        libgmp-dev \
-        libmpfr-dev \
         libncurses-dev \
         libssl-dev \
         libx11-dev \
@@ -58,6 +55,15 @@ RUN update-alternatives --install /usr/bin/g++ g++ $(which g++-9) 30 && \
     update-alternatives --install /usr/bin/gcc gcc $(which gcc-9) 30 && \
     update-alternatives --install /usr/bin/gcov gcov $(which gcov-9) 30 && \
     update-alternatives --install /usr/bin/gfortran gfortran $(which gfortran-9) 30
+
+# LLVM compiler
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        clang-8 \
+        libomp-8-dev && \
+    rm -rf /var/lib/apt/lists/*
+RUN update-alternatives --install /usr/bin/clang clang $(which clang-8) 30 && \
+    update-alternatives --install /usr/bin/clang++ clang++ $(which clang++-8) 30
 
 # CMake version 3.16.0
 RUN apt-get update -y && \
@@ -204,33 +210,32 @@ ENV CPATH=/usr/local/ucx/include:$CPATH \
     LIBRARY_PATH=/usr/local/ucx/lib:$LIBRARY_PATH \
     PATH=/usr/local/ucx/bin:$PATH
 
-# OpenMPI version 4.0.3
+ENV CC=clang \
+    CFLAGS=-fPIC \
+    CXX=clang++ \
+    CXXFLAGS=-fPIC \
+    FC=gfortran \
+    FCFLAGS=-fPIC
+
+# MPICH version 3.3.1
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        bzip2 \
         file \
-        hwloc \
-        libnuma-dev \
+        gzip \
         make \
         openssh-client \
         perl \
         tar \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.open-mpi.org/software/ompi/v4.0/downloads/openmpi-4.0.3.tar.bz2 && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/openmpi-4.0.3.tar.bz2 -C /var/tmp -j && \
-    cd /var/tmp/openmpi-4.0.3 &&   ./configure --prefix=/usr/local --enable-mpi-cxx --with-pmi=/usr/local/slurm-pmi2 --with-ucx=/usr/local/ucx --with-verbs --without-cuda && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.mpich.org/static/downloads/3.3.1/mpich-3.3.1.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/mpich-3.3.1.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/mpich-3.3.1 &&   ./configure --prefix=/usr/local/mpich --enable-cxx --enable-fortran && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/openmpi-4.0.3 /var/tmp/openmpi-4.0.3.tar.bz2
-ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH \
-    PATH=/usr/local/bin:$PATH
-
-RUN cd /usr/local/src && \
-    wget https://github.com/linux-test-project/lcov/archive/v1.15.tar.gz && \
-    tar -xvf v1.15.tar.gz && \
-    cd lcov-1.15 && \
-    make install
+    rm -rf /var/tmp/mpich-3.3.1 /var/tmp/mpich-3.3.1.tar.gz
+ENV LD_LIBRARY_PATH=/usr/local/mpich/lib:$LD_LIBRARY_PATH \
+    PATH=/usr/local/mpich/bin:$PATH
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata locales && \

--- a/Dockerfile.clang-mpich-dev-mlnx
+++ b/Dockerfile.clang-mpich-dev-mlnx
@@ -20,11 +20,8 @@ RUN apt-get update -y && \
         flex \
         ksh \
         less \
-        libboost-thread-dev \
         libcurl4-openssl-dev \
         libexpat1-dev \
-        libgmp-dev \
-        libmpfr-dev \
         libncurses-dev \
         libssl-dev \
         libx11-dev \
@@ -58,6 +55,15 @@ RUN update-alternatives --install /usr/bin/g++ g++ $(which g++-9) 30 && \
     update-alternatives --install /usr/bin/gcc gcc $(which gcc-9) 30 && \
     update-alternatives --install /usr/bin/gcov gcov $(which gcov-9) 30 && \
     update-alternatives --install /usr/bin/gfortran gfortran $(which gfortran-9) 30
+
+# LLVM compiler
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        clang-8 \
+        libomp-8-dev && \
+    rm -rf /var/lib/apt/lists/*
+RUN update-alternatives --install /usr/bin/clang clang $(which clang-8) 30 && \
+    update-alternatives --install /usr/bin/clang++ clang++ $(which clang++-8) 30
 
 # CMake version 3.16.0
 RUN apt-get update -y && \
@@ -112,23 +118,36 @@ RUN apt-get update -y && \
 
 RUN ln -s /usr/bin/python3 /usr/bin/python
 
-# OFED
+# Mellanox OFED version 4.5-1.0.1.0
 RUN apt-get update -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends -t bionic \
-        dapl2-utils \
-        ibutils \
-        ibverbs-providers \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ca-certificates \
+        gnupg \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+RUN wget -qO - https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox | apt-key add - && \
+    mkdir -p /etc/apt/sources.list.d && wget -q -nc --no-check-certificate -P /etc/apt/sources.list.d https://linux.mellanox.com/public/repo/mlnx_ofed/4.5-1.0.1.0/ubuntu18.04/mellanox_mlnx_ofed.list && \
+    apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ibverbs-utils \
-        infiniband-diags \
-        libdapl-dev \
-        libdapl2 \
-        libibmad-dev \
-        libibmad5 \
+        libibmad \
+        libibmad-devel \
+        libibumad \
+        libibumad-devel \
         libibverbs-dev \
         libibverbs1 \
+        libmlx4-1 \
+        libmlx4-dev \
+        libmlx5-1 \
+        libmlx5-dev \
         librdmacm-dev \
-        librdmacm1 \
-        rdmacm-utils && \
+        librdmacm1 && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        libpsm-infinipath1 \
+        libpsm-infinipath1-dev && \
     rm -rf /var/lib/apt/lists/*
 
 # SLURM PMI2 version 20.02.5
@@ -204,33 +223,32 @@ ENV CPATH=/usr/local/ucx/include:$CPATH \
     LIBRARY_PATH=/usr/local/ucx/lib:$LIBRARY_PATH \
     PATH=/usr/local/ucx/bin:$PATH
 
-# OpenMPI version 4.0.3
+ENV CC=clang \
+    CFLAGS=-fPIC \
+    CXX=clang++ \
+    CXXFLAGS=-fPIC \
+    FC=gfortran \
+    FCFLAGS=-fPIC
+
+# MPICH version 3.3.1
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        bzip2 \
         file \
-        hwloc \
-        libnuma-dev \
+        gzip \
         make \
         openssh-client \
         perl \
         tar \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.open-mpi.org/software/ompi/v4.0/downloads/openmpi-4.0.3.tar.bz2 && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/openmpi-4.0.3.tar.bz2 -C /var/tmp -j && \
-    cd /var/tmp/openmpi-4.0.3 &&   ./configure --prefix=/usr/local --enable-mpi-cxx --with-pmi=/usr/local/slurm-pmi2 --with-ucx=/usr/local/ucx --with-verbs --without-cuda && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.mpich.org/static/downloads/3.3.1/mpich-3.3.1.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/mpich-3.3.1.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/mpich-3.3.1 &&   ./configure --prefix=/usr/local/mpich --enable-cxx --enable-fortran && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/openmpi-4.0.3 /var/tmp/openmpi-4.0.3.tar.bz2
-ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH \
-    PATH=/usr/local/bin:$PATH
-
-RUN cd /usr/local/src && \
-    wget https://github.com/linux-test-project/lcov/archive/v1.15.tar.gz && \
-    tar -xvf v1.15.tar.gz && \
-    cd lcov-1.15 && \
-    make install
+    rm -rf /var/tmp/mpich-3.3.1 /var/tmp/mpich-3.3.1.tar.gz
+ENV LD_LIBRARY_PATH=/usr/local/mpich/lib:$LD_LIBRARY_PATH \
+    PATH=/usr/local/mpich/bin:$PATH
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata locales && \

--- a/Dockerfile.intel-oneapi-dev
+++ b/Dockerfile.intel-oneapi-dev
@@ -55,6 +55,9 @@ RUN apt-get update -y && \
         unzip \
         wget \
         wish \
+        apt-utils \
+        imagemagick \
+        vim \
         xserver-xorg && \
     rm -rf /var/lib/apt/lists/*
 
@@ -81,17 +84,4 @@ RUN cd /usr/local/src && \
     tar -xvf v1.15.tar.gz && \
     cd lcov-1.15 && \
     make install
-
-RUN apt-get update -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends -o=Dpkg::Use-Pty=0 \
-    tzdata locales && \
-    ln -fs /usr/share/zoneinfo/America/Denver /etc/localtime && \
-    locale-gen --purge en_US.UTF-8 && \
-    dpkg-reconfigure --frontend noninteractive tzdata && \
-    dpkg-reconfigure --frontend=noninteractive locales && \
-    update-locale "LANG=en_US.UTF-8" && \
-    update-locale "LANGUAGE=en_US:en"
-
-ENV LANG=en_US.UTF-8 \
-    LANGUAGE=en_US:en
 

--- a/Dockerfile.intel-oneapi-dev
+++ b/Dockerfile.intel-oneapi-dev
@@ -1,0 +1,97 @@
+# syntax=docker/dockerfile:experimental
+FROM jcsda/intel-oneapi-hpckit:ubuntu20
+
+SHELL ["/bin/bash", "-c"]
+
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends -o=Dpkg::Use-Pty=0 \
+        bc \
+        bison \
+        build-essential \
+        byacc \
+        csh \
+        curl \
+        dirmngr \
+        doxygen \
+        emacs \
+        file \
+        flex \
+        git \
+        git-flow \
+        gnupg2 \
+        graphviz \
+        ksh \
+        less \
+        libasound2 \
+        libbz2-dev \
+        libcurl4-openssl-dev \
+        libncurses5-dev \
+        libexpat1-dev \
+        libgtk2.0-common \
+        liblz4-dev \
+        libncurses-dev \
+        libpango-1.0.0 \
+        libsnappy-dev \
+        libssl-dev \
+        libx11-dev \
+        libxml2-dev \
+        linux-headers-aws \
+        lsb-release \
+        lynx \
+        make \
+        man-db \
+        nano \
+        nedit \
+        openssh-client \
+        openssh-server \
+        screen \
+        software-properties-common \
+        swig \
+        tcl \
+        tcsh \
+        texinfo \
+        texlive-latex-recommended \
+        tk \
+        unzip \
+        wget \
+        wish \
+        xserver-xorg && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.17/cmake-3.17.2-Linux-x86_64.sh && \
+    mkdir -p /home/builder/opt && \
+    /bin/sh /var/tmp/cmake-3.17.2-Linux-x86_64.sh --prefix=/home/builder/opt --skip-license && \
+    rm -rf /var/tmp/cmake-3.17.2-Linux-x86_64.sh
+
+RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends git-lfs && \
+    git lfs install
+
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        python3-dev \
+        python3-pip \
+        python3-scipy \
+        python3-yaml && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN cd /usr/local/src && \
+    wget https://github.com/linux-test-project/lcov/archive/v1.15.tar.gz && \
+    tar -xvf v1.15.tar.gz && \
+    cd lcov-1.15 && \
+    make install
+
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends -o=Dpkg::Use-Pty=0 \
+    tzdata locales && \
+    ln -fs /usr/share/zoneinfo/America/Denver /etc/localtime && \
+    locale-gen --purge en_US.UTF-8 && \
+    dpkg-reconfigure --frontend noninteractive tzdata && \
+    dpkg-reconfigure --frontend=noninteractive locales && \
+    update-locale "LANG=en_US.UTF-8" && \
+    update-locale "LANGUAGE=en_US:en"
+
+ENV LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en
+

--- a/Dockerfile.intel-oneapi-hpckit-ubuntu20
+++ b/Dockerfile.intel-oneapi-hpckit-ubuntu20
@@ -1,0 +1,29 @@
+# Copyright (c) 2019-2020 Intel Corporation.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# requires oneapi-basekit image, assumes oneapi apt repo is configured
+ARG base_image="intel-oneapi-os-tools:ubuntu20"
+FROM "$base_image"
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# install Intel(R) oneAPI HPC Toolkit
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends -o=Dpkg::Use-Pty=0 \
+    intel-hpckit-getting-started \
+    intel-oneapi-clck \
+    intel-oneapi-common-licensing \
+    intel-oneapi-common-vars \
+    intel-oneapi-dev-utilities \
+    intel-oneapi-dpcpp-cpp-compiler-pro \
+    intel-oneapi-ifort \
+    intel-oneapi-inspector \
+    intel-oneapi-itac \
+    intel-oneapi-mpi-devel \
+    --
+
+RUN echo "if [ -z \"$INTEL_SH_GUARD\" ]; then" > /etc/profile.d/intel.sh \
+    && echo "    source /opt/intel/oneapi/setvars.sh -i_mpi_library_kind=release_mt" >> /etc/profile.d/intel.sh \
+    && echo "fi" >> /etc/profile.d/intel.sh \
+    && echo "export INTEL_SH_GUARD=1" >> /etc/profile.d/intel.sh \
+    && chmod a+x /etc/profile.d/intel.sh

--- a/Dockerfile.intel-oneapi-hpckit-ubuntu20
+++ b/Dockerfile.intel-oneapi-hpckit-ubuntu20
@@ -20,6 +20,7 @@ RUN apt-get update -y && \
     intel-oneapi-inspector \
     intel-oneapi-itac \
     intel-oneapi-mpi-devel \
+    intel-oneapi-mkl-devel \
     --
 
 RUN echo "if [ -z \"$INTEL_SH_GUARD\" ]; then" > /etc/profile.d/intel.sh \

--- a/Dockerfile.intel-oneapi-hpckit-ubuntu20
+++ b/Dockerfile.intel-oneapi-hpckit-ubuntu20
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 # requires oneapi-basekit image, assumes oneapi apt repo is configured
-ARG base_image="intel-oneapi-os-tools:ubuntu20"
+ARG base_image="jcsda/intel-oneapi-os-tools:ubuntu20"
 FROM "$base_image"
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/Dockerfile.intel-oneapi-os-tools-ubuntu20
+++ b/Dockerfile.intel-oneapi-os-tools-ubuntu20
@@ -1,0 +1,28 @@
+# Copyright (c) 2019-2020 Intel Corporation.
+# SPDX-License-Identifier: BSD-3-Clause
+FROM ubuntu:20.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
+
+# install OS tools
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends -o=Dpkg::Use-Pty=0 \
+    # make
+    build-essential \
+    # library helper
+    pkg-config \
+    cmake \
+    ca-certificates \
+    gnupg
+
+# add apt repo public key
+ARG url=https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+ADD $url /
+RUN file=$(basename "$url") && \
+    apt-key add "$file" && \
+    rm "$file"
+
+# configure the repository
+ARG apt_repo=https://apt.repos.intel.com/oneapi
+RUN echo "deb $apt_repo all main" > /etc/apt/sources.list.d/oneAPI.list

--- a/base-dev.py
+++ b/base-dev.py
@@ -35,7 +35,8 @@ Stage0 += apt_get(ospackages=['tcsh','csh','ksh', 'openssh-server','libncurses-d
                               'libssl-dev','libx11-dev','less','man-db','tk','tcl','swig',
                               'bc','file','flex','bison','libexpat1-dev',
                               'libxml2-dev','unzip','wish','curl','wget','time',
-                              'libcurl4-openssl-dev','nano','screen','lsb-release'])
+                              'libcurl4-openssl-dev','nano','screen','lsb-release',
+                              'libgmp-dev','libmpfr-dev','libboost-thread-dev'])
 
 # Install GNU compilers - even clang needs gfortran
 Stage0 += gnu(extra_repository=True,version='9')

--- a/base-dev.py
+++ b/base-dev.py
@@ -29,7 +29,7 @@ Stage0 += apt_get(ospackages=['build-essential','gnupg2','apt-utils'])
 Stage0 += shell(commands=['apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6B05F25D762E3157',
                           'apt-get update'])
 
-# useful system tools 
+# useful system tools
 # libexpat is required by udunits
 Stage0 += apt_get(ospackages=['tcsh','csh','ksh', 'openssh-server','libncurses-dev',
                               'libssl-dev','libx11-dev','less','man-db','tk','tcl','swig',
@@ -40,14 +40,14 @@ Stage0 += apt_get(ospackages=['tcsh','csh','ksh', 'openssh-server','libncurses-d
 # Install GNU compilers - even clang needs gfortran
 Stage0 += gnu(extra_repository=True,version='9')
 
-# Install clang compilers 
+# Install clang compilers
 if (mycompiler.lower() == "clang"):
     Stage0 += llvm(extra_repository=True, version='8')
 
 # get an up-to-date version of CMake
 Stage0 += cmake(eula=True,version="3.16.0")
 
-# editors, document tools, git, and git-flow                   
+# editors, document tools, git, and git-flow
 Stage0 += apt_get(ospackages=['emacs','vim','nedit','graphviz','doxygen',
                               'texlive-latex-recommended','texinfo','lynx',
                               'git','git-flow','imagemagick','tex4ht'])
@@ -56,9 +56,9 @@ Stage0 += shell(commands=
                 ['curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash',
                  'apt-get update','apt-get install -y --no-install-recommends git-lfs', 'git lfs install'])
 
-# autoconfig and debuggers                  
+# autoconfig and debuggers
 Stage0 += apt_get(ospackages=['autoconf','pkg-config','ddd','gdb','kdbg','valgrind'])
-    
+
 # python3
 Stage0 += apt_get(ospackages=['python3-pip','python3-dev','python3-yaml',
                               'python3-scipy'])
@@ -66,7 +66,7 @@ Stage0 += shell(commands=['ln -s /usr/bin/python3 /usr/bin/python'])
 
 # Mellanox or inbox OFED
 if (hpc):
-    if (mxofed.lower() == "true"): 
+    if (mxofed.lower() == "true"):
         Stage0 += mlnx_ofed(version='4.5-1.0.1.0')
     else:
         Stage0 += ofed()
@@ -98,10 +98,10 @@ if (hpc):
             Stage0 += environment(variables={'FC':'gfortran','CC':'gcc','CXX':'g++',
                 'CFLAGS':'-fPIC','CXXFLAGS':'-fPIC','FCFLAGS':'-fPIC'})
         Stage0 += mpich(version='3.3.1', configure_opts=['--enable-cxx --enable-fortran'])
-    
+
     else:
         # OpenMPI
-        Stage0 += openmpi(prefix='/usr/local', version='4.0.3', cuda=False, infiniband=infiniband, 
+        Stage0 += openmpi(prefix='/usr/local', version='4.0.3', cuda=False, infiniband=infiniband,
                           pmi="/usr/local/slurm-pmi2",ucx="/usr/local/ucx", with_psm=withpsm,
                           configure_opts=['--enable-mpi-cxx'])
 else:
@@ -112,11 +112,17 @@ else:
         Stage0 += environment(variables={'FC':'gfortran','CC':'clang','CXX':'clang++',
             'CFLAGS':'-fPIC','CXXFLAGS':'-fPIC','FCFLAGS':'-fPIC'})
         Stage0 += mpich(version='3.3.1', configure_opts=['--enable-cxx --enable-fortran'])
-    
+
     else:
         # OpenMPI
-        Stage0 += openmpi(prefix='/usr/local', version='4.0.3', cuda=False, infiniband=False, 
+        Stage0 += openmpi(prefix='/usr/local', version='4.0.3', cuda=False, infiniband=False,
                           configure_opts=['--enable-mpi-cxx'])
+
+# lcov 1.15
+Stage0 += shell(commands=
+          ['cd /usr/local/src',
+           'wget https://github.com/linux-test-project/lcov/archive/v1.15.tar.gz',
+           'tar -xvf v1.15.tar.gz', 'cd lcov-1.15', 'make install'])
 
 # locales time zone and language support
 Stage0 += shell(commands=['apt-get update',
@@ -128,4 +134,3 @@ Stage0 += shell(commands=['apt-get update',
      'update-locale \"LANG=en_US.UTF-8\"',
      'update-locale \"LANGUAGE=en_US:en\"'])
 Stage0 += environment(variables={'LANG':'en_US.UTF-8','LANGUAGE':'en_US:en'})
-

--- a/generated.version
+++ b/generated.version
@@ -1,2 +1,2 @@
 Generated with hpccm version: 
-20.3.0
+20.11.0

--- a/generated.version
+++ b/generated.version
@@ -1,2 +1,2 @@
 Generated with hpccm version: 
-20.11.0
+20.9.0

--- a/make_dockerimage.sh
+++ b/make_dockerimage.sh
@@ -58,8 +58,8 @@ echo $CompilerName
 if [[ $CompilerName =~ "intel" ]]; then
 
     echo "Building intel container"
-    docker image build -f Dockerfile.intel-oneapi-os-tools-ubuntu20 -t jcsda/intel-oneapi-os-tools:ubuntu20 .
-    docker image build -f Dockerfile.intel-oneapi-hpckit-ubuntu20 -t jcsda/intel-oneapi-hpckit:ubuntu20 .
+    docker image build --no-cache -f Dockerfile.intel-oneapi-os-tools-ubuntu20 -t jcsda/intel-oneapi-os-tools:ubuntu20 .
+    docker image build --no-cache -f Dockerfile.intel-oneapi-hpckit-ubuntu20 -t jcsda/intel-oneapi-hpckit:ubuntu20 .
     docker image build --no-cache -f Dockerfile.intel-oneapi-dev -t jcsda/docker_base-intel-oneapi-dev:${TAG} .
     exit 0
 fi

--- a/make_dockerimage.sh
+++ b/make_dockerimage.sh
@@ -53,6 +53,15 @@ HPC=${3:-"0"}
 CompilerName=$(echo $CNAME| cut -d- -f1)
 MPIName=$(echo $CNAME| cut -d- -f2)
 
+echo $CompilerName
+
+if [[ $CompilerName =~ "intel" ]]; then
+
+    echo "Building intel container"
+    docker image build --no-cache -f Dockerfile.intel-oneapi-dev -t intel-oneapi-dev:$ubuntu .
+    exit 0
+fi
+
 case ${HPC} in
     "0")
         hpccm --recipe base-dev.py --userarg compiler=${CompilerName} \

--- a/make_dockerimage.sh
+++ b/make_dockerimage.sh
@@ -58,7 +58,9 @@ echo $CompilerName
 if [[ $CompilerName =~ "intel" ]]; then
 
     echo "Building intel container"
-    docker image build --no-cache -f Dockerfile.intel-oneapi-dev -t intel-oneapi-dev:$ubuntu .
+    docker image build -f Dockerfile.intel-oneapi-os-tools-ubuntu20 -t jcsda/intel-oneapi-os-tools:ubuntu20 .
+    docker image build -f Dockerfile.intel-oneapi-hpckit-ubuntu20 -t jcsda/intel-oneapi-hpckit:ubuntu20 .
+    docker image build --no-cache -f Dockerfile.intel-oneapi-dev -t jcsda/docker_base-intel-oneapi-dev:${TAG} .
     exit 0
 fi
 

--- a/make_dockerimage.sh
+++ b/make_dockerimage.sh
@@ -42,12 +42,12 @@ function get_ans {
 
 #------------------------------------------------------------------------
 if [[ $# -lt 1 ]]; then
-   echo "usage: make_dockerfile <name>"
+   echo "usage: make_dockerfile <name> [<tag>] [<HPC>]"
    exit 1
 fi
 
 CNAME=${1:-"gnu-openmpi-dev"}
-TAG=${2:-"latest"}
+TAG=${2:-"beta"}
 HPC=${3:-"0"}
 
 CompilerName=$(echo $CNAME| cut -d- -f1)
@@ -82,37 +82,10 @@ esac
 echo "Generated with hpccm version: " > generated.version
 hpccm --version >> generated.version
 
-if [[ ${TAG} == 'latest' ]]; then
+docker image build --no-cache -f Dockerfile.$CNAME -t jcsda/docker_base-$CNAME:${TAG} .
 
-    docker image build --no-cache -f Dockerfile.$CNAME -t jcsda/docker_base-$CNAME:beta .
+get_ans "Push to Docker Hub?"
 
-    #------------------------------------------------------------------------
-    get_ans "Push to Docker Hub and back up?"
-
-    if [[ $ans == y ]] ; then
-
-        # save previous image in case something goes wrong
-        docker pull jcsda/docker_base-$CNAME:latest
-        docker tag jcsda/docker_base-$CNAME:latest jcsda/docker_base-$CNAME:revert
-        docker push jcsda/docker_base-$CNAME:revert
-        docker rmi jcsda/docker_base-$CNAME:latest
-
-        # push new image and re-tag it with latest
-        docker tag jcsda/docker_base-$CNAME:beta jcsda/docker_base-$CNAME:latest
-        docker rmi jcsda/docker_base-$CNAME:beta
-        docker push jcsda/docker_base-$CNAME:latest
-
-    fi
-    #------------------------------------------------------------------------
-
-else
-
-    docker image build --no-cache -f Dockerfile.$CNAME -t jcsda/docker_base-$CNAME:${TAG} .
-
-    get_ans "Push to Docker Hub?"
-
-    if [[ $ans == y ]] ; then
-        docker push jcsda/docker_base-$CNAME:${TAG}
-    fi
-
+if [[ $ans == y ]] ; then
+    docker push jcsda/docker_base-$CNAME:${TAG}
 fi

--- a/push_beta_to_latest.sh
+++ b/push_beta_to_latest.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# © Copyright 2020-2020 UCAR
+# This software is licensed under the terms of the Apache Licence Version 2.0 which can be obtained at
+# http://www.apache.org/licenses/LICENSE-2.0.
+
+
+#
+# push_beta_to_latest.sh - Make test version of Docker image the latest on Docker Hub
+#
+# Useage:
+# push_beta_to_latest.sh <name> <tag>
+#
+# <name> - name of image to build in format <compiler>-<mpi>-<type>
+#           where <type> is dev (development) or app (application)
+#           Default: gnu-openmpi-dev
+#
+# <tag> - optional tag for input docker image (default beta)
+#
+#------------------------------------------------------------------------
+function get_ans {
+    ans=''
+    while [[ $ans != y ]] && [[ $ans != n ]]; do
+      echo $1
+      read ans < /dev/stdin
+      if [[ $ans != y ]] && [[ $ans != n ]]; then echo "You must enter y or n"; fi
+    done
+}
+
+#------------------------------------------------------------------------
+if [[ $# -lt 1 ]]; then
+   echo "usage: push_beta_to_latest <name> [<tag>]"
+   exit 1
+fi
+
+CNAME=${1:-"gnu-openmpi-dev"}
+TAG=${2:-"beta"}
+
+#------------------------------------------------------------------------
+get_ans "Push to Docker Hub and back up?"
+
+if [[ $ans == y ]] ; then
+
+    # save previous image in case something goes wrong
+    docker pull jcsda/docker_base-$CNAME:latest
+    docker tag jcsda/docker_base-$CNAME:latest jcsda/docker_base-$CNAME:revert
+    docker push jcsda/docker_base-$CNAME:revert
+    docker rmi jcsda/docker_base-$CNAME:latest
+
+    # push new image and re-tag it with latest
+    docker tag jcsda/docker_base-$CNAME:beta jcsda/docker_base-$CNAME:latest
+    docker rmi jcsda/docker_base-$CNAME:beta
+    docker push jcsda/docker_base-$CNAME:latest
+
+fi
+    #------------------------------------------------------------------------


### PR DESCRIPTION
## Description

The main change here is to add a series of Dockerfiles for building an intel oneapi container and modifying the build script accordingly.  I also split the build script into separate build and push scripts to facilitate testing.  The reason for having three intel oneapi Dockerfiles is because the first two are pretty much straight from intel, with minor changes, hence the intel copyright at the top.   The third one is JEDI customizations.

Don't spend much time scrutinizing the gnu and clang Dockerfiles - these are generated automatically by the base-dev.py script.  The only reason they are different is becuause I included the HPC options in the build.  The intel Dockerfiles are not generated automatically.

I also added package installs of gmp, mpfr, and boost-thread to build CGAL.  I know this is not necessary but currently jedi-stack is not configured to build CGAL without these so until it is, this was the easiest option.

### Issue(s) addressed

See also 

https://github.com/JCSDA-internal/jedi-tools/issues/134
https://github.com/JCSDA-internal/containers/issues/43

## Dependencies

If there are PRs that need to be merged before or along with this one, please add "waiting for another PR" label and list the dependencies in the other repositories (example below). Note that the branches in the other repositories should have matching names for the automated tests to pass.
Waiting on the following PRs:
- waiting on JCSDA/eckit/pull/<pr_number>
- waiting on JCSDA/atlas/pull/<pr_number>

## Impact

If changes in this PR will affect other repositories, please add a "waiting for other repos" label, and list the repositories that will be affected to the best of your knowledge (example below).
Requires changes in the following repositories:
- [ ] saber
- [ ] ioda
- [ ] ufo
- [ ] ...

If changes in this PR require updating test data on AWS please add an "update test data" label and list the test data that needs to be updated to the best of your knowledge (example below).
Requires updating AWS test data for the following repositories:
- [ ] saber
- [ ] ioda
- [ ] ...

Note: to automatically run saber, ioda and ufo tests with this PR, push a commit containing "trigger pipeline", e.g.:
git commit --allow-empty -m 'trigger pipeline'
