### PR TITLE
Bugfix/slurm

### DIFF
--- a/Dockerfile.clang-mpich-dev
+++ b/Dockerfile.clang-mpich-dev
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -6,9 +6,6 @@ RUN apt-get update -y && \
         build-essential \
         gnupg2 && \
     rm -rf /var/lib/apt/lists/*
-
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6B05F25D762E3157 && \
-    apt-get update
 
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -20,8 +17,11 @@ RUN apt-get update -y && \
         flex \
         ksh \
         less \
+        libboost-thread-dev \
         libcurl4-openssl-dev \
         libexpat1-dev \
+        libgmp-dev \
+        libmpfr-dev \
         libncurses-dev \
         libssl-dev \
         libx11-dev \
@@ -43,9 +43,6 @@ RUN apt-get update -y && \
 
 # GNU compiler
 RUN apt-get update -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends software-properties-common && \
-    apt-add-repository ppa:ubuntu-toolchain-r/test -y && \
-    apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         g++-9 \
         gcc-9 \
@@ -65,16 +62,16 @@ RUN apt-get update -y && \
 RUN update-alternatives --install /usr/bin/clang clang $(which clang-8) 30 && \
     update-alternatives --install /usr/bin/clang++ clang++ $(which clang++-8) 30
 
-# CMake version 3.16.0
+# CMake version 3.19.2
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         make \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.16/cmake-3.16.0-Linux-x86_64.sh && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.19/cmake-3.19.2-Linux-x86_64.sh && \
     mkdir -p /usr/local && \
-    /bin/sh /var/tmp/cmake-3.16.0-Linux-x86_64.sh --prefix=/usr/local --skip-license && \
-    rm -rf /var/tmp/cmake-3.16.0-Linux-x86_64.sh
+    /bin/sh /var/tmp/cmake-3.19.2-Linux-x86_64.sh --prefix=/usr/local --skip-license && \
+    rm -rf /var/tmp/cmake-3.19.2-Linux-x86_64.sh
 ENV PATH=/usr/local/bin:$PATH
 
 RUN apt-get update -y && \
@@ -95,15 +92,15 @@ RUN apt-get update -y && \
 
 RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && \
     apt-get update && \
-    apt-get install -y --no-install-recommends git-lfs && \
-    git lfs install
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends git-lfs && \
+    git lfs install --skip-repo
 
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         autoconf \
+        clang-tidy \
         ddd \
         gdb \
-        kdbg \
         pkg-config \
         valgrind && \
     rm -rf /var/lib/apt/lists/*
@@ -120,7 +117,7 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 
 # OFED
 RUN apt-get update -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends -t bionic \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends -t focal \
         dapl2-utils \
         ibutils \
         ibverbs-providers \
@@ -136,23 +133,6 @@ RUN apt-get update -y && \
         librdmacm1 \
         rdmacm-utils && \
     rm -rf /var/lib/apt/lists/*
-
-# SLURM PMI2 version 20.02.5
-RUN apt-get update -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        bzip2 \
-        file \
-        make \
-        perl \
-        tar \
-        wget && \
-    rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://download.schedmd.com/slurm/slurm-20.02.5.tar.bz2 && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/slurm-20.02.5.tar.bz2 -C /var/tmp -j && \
-    cd /var/tmp/slurm-20.02.5 &&   ./configure --prefix=/usr/local/slurm-pmi2 && \
-    cd /var/tmp/slurm-20.02.5 && \
-    make -C contribs/pmi2 install && \
-    rm -rf /var/tmp/slurm-20.02.5 /var/tmp/slurm-20.02.5.tar.bz2
 
 # KNEM version 1.1.4
 RUN apt-get update -y && \
@@ -210,6 +190,32 @@ ENV CPATH=/usr/local/ucx/include:$CPATH \
     LIBRARY_PATH=/usr/local/ucx/lib:$LIBRARY_PATH \
     PATH=/usr/local/ucx/bin:$PATH
 
+# SLURM PMI2 version 20.02.7
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        default-libmysqlclient-dev \
+        libfreeipmi-dev \
+        libfreeipmi-dev \
+        libglib2.0-0 \
+        libglib2.0-dev \
+        libgtk-3-0 \
+        libgtk-3-dev \
+        libhwloc-dev \
+        libjson-c-dev \
+        liblua5.2-0 \
+        liblua5.2-dev \
+        libmunge-dev \
+        libmunge2 \
+        libpam0g-dev \
+        libyaml-dev && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://download.schedmd.com/slurm/slurm-20.02.7.tar.bz2 && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/slurm-20.02.7.tar.bz2 -C /var/tmp -j && \
+    cd /var/tmp/slurm-20.02.7 &&   ./configure --prefix=/usr/local/slurm-pmi2 && \
+    cd /var/tmp/slurm-20.02.7 && \
+    make -C contribs/pmi2 install && \
+    rm -rf /var/tmp/slurm-20.02.7 /var/tmp/slurm-20.02.7.tar.bz2
+
 ENV CC=clang \
     CFLAGS=-fPIC \
     CXX=clang++ \
@@ -237,16 +243,10 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://
 ENV LD_LIBRARY_PATH=/usr/local/mpich/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/mpich/bin:$PATH
 
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata locales && \
-    ln -fs /usr/share/zoneinfo/America/Denver /etc/localtime && \
-    locale-gen --purge en_US.UTF-8 && \
-    dpkg-reconfigure --frontend noninteractive tzdata && \
-    dpkg-reconfigure --frontend=noninteractive locales && \
-    update-locale "LANG=en_US.UTF-8" && \
-    update-locale "LANGUAGE=en_US:en"
-
-ENV LANG=en_US.UTF-8 \
-    LANGUAGE=en_US:en
+RUN cd /usr/local/src && \
+    wget https://github.com/linux-test-project/lcov/archive/v1.15.tar.gz && \
+    tar -xvf v1.15.tar.gz && \
+    cd lcov-1.15 && \
+    make install
 
 

--- a/Dockerfile.gnu-openmpi-dev
+++ b/Dockerfile.gnu-openmpi-dev
@@ -106,6 +106,107 @@ RUN apt-get update -y && \
 
 RUN ln -s /usr/bin/python3 /usr/bin/python
 
+# OFED
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends -t focal \
+        dapl2-utils \
+        ibutils \
+        ibverbs-providers \
+        ibverbs-utils \
+        infiniband-diags \
+        libdapl-dev \
+        libdapl2 \
+        libibmad-dev \
+        libibmad5 \
+        libibverbs-dev \
+        libibverbs1 \
+        librdmacm-dev \
+        librdmacm1 \
+        rdmacm-utils && \
+    rm -rf /var/lib/apt/lists/*
+
+# KNEM version 1.1.4
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ca-certificates \
+        git && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /var/tmp && cd /var/tmp && git clone --depth=1 --branch knem-1.1.4 https://gitlab.inria.fr/knem/knem.git knem && cd - && \
+    mkdir -p /usr/local/knem && \
+    cd /var/tmp/knem && \
+    mkdir -p /usr/local/knem/include && \
+    cp common/*.h /usr/local/knem/include && \
+    rm -rf /var/tmp/knem
+ENV CPATH=/usr/local/knem/include:$CPATH
+
+# XPMEM branch master
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        autoconf \
+        automake \
+        ca-certificates \
+        file \
+        git \
+        libtool \
+        make && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /var/tmp && cd /var/tmp && git clone --depth=1 --branch master https://gitlab.com/hjelmn/xpmem.git xpmem && cd - && \
+    cd /var/tmp/xpmem && \
+    autoreconf --install && \
+    cd /var/tmp/xpmem &&   ./configure --prefix=/usr/local/xpmem --disable-kernel-module && \
+    make -j$(nproc) && \
+    make -j$(nproc) install && \
+    rm -rf /var/tmp/xpmem
+ENV CPATH=/usr/local/xpmem/include:$CPATH \
+    LD_LIBRARY_PATH=/usr/local/xpmem/lib:$LD_LIBRARY_PATH \
+    LIBRARY_PATH=/usr/local/xpmem/lib:$LIBRARY_PATH
+
+# UCX version 1.9.0
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        binutils-dev \
+        file \
+        libnuma-dev \
+        make \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/openucx/ucx/releases/download/v1.9.0/ucx-1.9.0.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/ucx-1.9.0.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/ucx-1.9.0 &&   ./configure --prefix=/usr/local/ucx --disable-assertions --disable-debug --disable-doxygen-doc --disable-logging --disable-params-check --enable-optimizations --with-knem --with-rdmacm --with-verbs --with-xpmem --without-cuda && \
+    make -j$(nproc) && \
+    make -j$(nproc) install && \
+    rm -rf /var/tmp/ucx-1.9.0 /var/tmp/ucx-1.9.0.tar.gz
+ENV CPATH=/usr/local/ucx/include:$CPATH \
+    LD_LIBRARY_PATH=/usr/local/ucx/lib:$LD_LIBRARY_PATH \
+    LIBRARY_PATH=/usr/local/ucx/lib:$LIBRARY_PATH \
+    PATH=/usr/local/ucx/bin:$PATH
+
+# SLURM PMI2 version 20.02.7
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        default-libmysqlclient-dev \
+        libfreeipmi-dev \
+        libfreeipmi-dev \
+        libglib2.0-0 \
+        libglib2.0-dev \
+        libgtk-3-0 \
+        libgtk-3-dev \
+        libhwloc-dev \
+        libjson-c-dev \
+        liblua5.2-0 \
+        liblua5.2-dev \
+        libmunge-dev \
+        libmunge2 \
+        libpam0g-dev \
+        libyaml-dev && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://download.schedmd.com/slurm/slurm-20.02.7.tar.bz2 && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/slurm-20.02.7.tar.bz2 -C /var/tmp -j && \
+    cd /var/tmp/slurm-20.02.7 &&   ./configure --prefix=/usr/local/slurm-pmi2 && \
+    cd /var/tmp/slurm-20.02.7 && \
+    make -C contribs/pmi2 install && \
+    rm -rf /var/tmp/slurm-20.02.7 /var/tmp/slurm-20.02.7.tar.bz2
+
 # OpenMPI version 4.0.3
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -121,7 +222,7 @@ RUN apt-get update -y && \
     rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.open-mpi.org/software/ompi/v4.0/downloads/openmpi-4.0.3.tar.bz2 && \
     mkdir -p /var/tmp && tar -x -f /var/tmp/openmpi-4.0.3.tar.bz2 -C /var/tmp -j && \
-    cd /var/tmp/openmpi-4.0.3 &&   ./configure --prefix=/usr/local --enable-mpi-cxx --without-cuda --without-verbs && \
+    cd /var/tmp/openmpi-4.0.3 &&   ./configure --prefix=/usr/local --enable-mpi-cxx --with-pmi=/usr/local/slurm-pmi2 --with-ucx=/usr/local/ucx --with-verbs --without-cuda && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
     rm -rf /var/tmp/openmpi-4.0.3 /var/tmp/openmpi-4.0.3.tar.bz2

--- a/Dockerfile.intel-impi-dev
+++ b/Dockerfile.intel-impi-dev
@@ -169,7 +169,7 @@ ENV CPATH=/usr/local/ucx/include:$CPATH \
     LIBRARY_PATH=/usr/local/ucx/lib:$LIBRARY_PATH \
     PATH=/usr/local/ucx/bin:$PATH
 
-# SLURM PMI2 version 19.05.4
+# SLURM PMI2 version 20.02.7
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         default-libmysqlclient-dev \
@@ -188,12 +188,12 @@ RUN apt-get update -y && \
         libpam0g-dev \
         libyaml-dev && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://download.schedmd.com/slurm/slurm-19.05.4.tar.bz2 && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/slurm-19.05.4.tar.bz2 -C /var/tmp -j && \
-    cd /var/tmp/slurm-19.05.4 &&   ./configure --prefix=/usr/local/slurm-pmi2 && \
-    cd /var/tmp/slurm-19.05.4 && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://download.schedmd.com/slurm/slurm-20.02.7.tar.bz2 && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/slurm-20.02.7.tar.bz2 -C /var/tmp -j && \
+    cd /var/tmp/slurm-20.02.7 &&   ./configure --prefix=/usr/local/slurm-pmi2 && \
+    cd /var/tmp/slurm-20.02.7 && \
     make -C contribs/pmi2 install && \
-    rm -rf /var/tmp/slurm-19.05.4 /var/tmp/slurm-19.05.4.tar.bz2
+    rm -rf /var/tmp/slurm-20.02.7 /var/tmp/slurm-20.02.7.tar.bz2
 
 RUN cd /usr/local/src && \
     wget https://github.com/linux-test-project/lcov/archive/v1.15.tar.gz && \

--- a/base-dev.py
+++ b/base-dev.py
@@ -97,7 +97,7 @@ if (hpc):
     # Warning: installing slurm-pmi2 before the compilers and jedi-stack means
     # that some options are not selected, such as support for hdf5, pmix, and netloc
     # If we're preformance tuning, we may want to re-install this at later stage
-    Stage0 += slurm_pmi2(version='19.05.4',ospackages=['libgtk-3-0','libgtk-3-dev',
+    Stage0 += slurm_pmi2(version='20.02.7',ospackages=['libgtk-3-0','libgtk-3-dev',
               'libglib2.0-0','libglib2.0-dev','liblua5.2-0','liblua5.2-dev',
               'libmunge2','libmunge-dev','libyaml-dev','libhwloc-dev','libjson-c-dev',
               'libfreeipmi-dev','default-libmysqlclient-dev','libpam0g-dev',


### PR DESCRIPTION
## Description

The only significant change here is to upgrade the slurm version number.  The old version number is no longer available from that download site.  I noticed this while generating new containers for the release.

The changes to the Dockerfiles are not significant.  These are automatically generated by the `base-dev.py` script which has not changed.

## Acceptance Criteria (Definition of Done)

Container build scripts run successfully with HPC option enabled.

## Dependencies

None

## Impact

None

## Test Data

None